### PR TITLE
arduino cmake 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - mkdir -p hardware/keyboardio
   - git clone --recursive https://github.com/keyboardio/Arduino-Boards.git hardware/keyboardio/avr
   - cd hardware/keyboardio/avr/libraries
-  - git clone --recursive https://github.com/noseglasses/Kaleidoscope-CMake.git
+  - git clone -b regression_testing ${TRAVIS_BRANCH} --recursive https://github.com/noseglasses/Kaleidoscope-CMake.git
   - cd $HOME
   - mkdir kcm_build
   - cd kcm_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - mkdir -p hardware/keyboardio
   - git clone --recursive https://github.com/keyboardio/Arduino-Boards.git hardware/keyboardio/avr
   - cd hardware/keyboardio/avr/libraries
-  - git clone -b regression_testing ${TRAVIS_BRANCH} --recursive https://github.com/noseglasses/Kaleidoscope-CMake.git
+  - git clone -b ${TRAVIS_BRANCH} --recursive https://github.com/noseglasses/Kaleidoscope-CMake.git
   - cd $HOME
   - mkdir kcm_build
   - cd kcm_build

--- a/cmake/cross_build.include.cmake
+++ b/cmake/cross_build.include.cmake
@@ -39,21 +39,25 @@ if(NOT KALEIDOSCOPE_HOST_BUILD)
    -fno-exceptions \
    -ffunction-sections \
    -fdata-sections\
-   ")
+   "
+   )
 else()
 
    # Define empty flags. Else Arduino-CMake will define something Arduino
    # specific, which we have to avoid for host builds.
    #
-   set(ARDUINO_C_FLAGS "")
+   set(ARDUINO_C_FLAGS "" CACHE INTERNAL "")
    set(ARDUINO_CXX_FLAGS "\
    -std=gnu++11 \
    -Wall \
    -Wextra \
    -DARDUINO_VIRTUAL\
-   ")
+   " CACHE INTERNAL "")
    
    set(ARDUINO_LIBRARIES_PATH "___dummy__")
+   set(ARDUINO_SDK_PATH "___dummy__")
+   set(ARDUINO_CMAKE_SKIP_DETECT_VERSION TRUE CACHE INTERNAL "")
+   set(ARDUINO_CMAKE_SKIP_TEST_SETUP TRUE CACHE INTERNAL "")
    
    # Include Arduino.cmake directly to avoid Arduino toolchain setup as
    # it would be performed through defining CMAKE_TOOLCHAIN_FILE

--- a/cmake/platform.include.cmake
+++ b/cmake/platform.include.cmake
@@ -206,6 +206,7 @@ if(NOT EXISTS "${hardware_definition_file}")
    message(FATAL_ERROR "Unnable to find hardware definition file \"${hardware_definition_file}\" for \
 KALEIDOSCOPE_BOARD=${KALEIDOSCOPE_BOARD}")
 else()
+   message("Including hardware definition ${hardware_definition_file}")
    include("${hardware_definition_file}")
 endif()
 


### PR DESCRIPTION
Changes to enable using arduino-cmake 2.x as basis for Kaleidoscope-CMake builds.